### PR TITLE
Set config-version to 2 in project yml

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,7 @@
 
 name: 'jaffle_shop'
 version: '0.1'
+config-version: 2
 profile: 'jaffle_shop'
 source-paths: ["models"]
 analysis-paths: ["analysis"]


### PR DESCRIPTION
Should prevent SQL compiles from failing for dbt runtimes >v0.19.0

See [reference](https://docs.getdbt.com/reference/project-configs/config-version)